### PR TITLE
Hero equipment inventory max height fix.

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -368,6 +368,8 @@ body {
   margin-top: 10px;
   display: flex;
   flex-wrap: wrap;
+  max-height: 100px;
+  overflow: auto;
 }
 
 #heroEquipment > .inventory-item__wrapper-img {

--- a/index.html
+++ b/index.html
@@ -1406,7 +1406,7 @@
 				var id = "artid" + rnd;
 
 				artefactIds.push(id);
-				setTimeout(() => { resolve(artefactIds) }, 2500);
+				resolve(artefactIds);
 			});
 		},
 		generateMap : function () {
@@ -4641,7 +4641,7 @@
 		// loc = {};
 		// tapX = e.targetTouches ? e.targetTouches[0].pageX : e.pageX;
 		// tapY = e.targetTouches ? e.targetTouches[0].pageY : e.pageY;
-		
+
 		// loc.x = (tapX - 9) * canvasScaleRatio;
 		// loc.y = (tapY - 58) * canvasScaleRatio;
 		// for (bi=0;bi<buildingsInTownB.length;bi++){


### PR DESCRIPTION
1. Remove unnecessary setTimeout from generateBlackmarketGoods method
2. Equipment inventory doesn't break hero window now.